### PR TITLE
Upgrade for-own dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "object"
   ],
   "dependencies": {
-    "for-own": "^0.1.4",
+    "for-own": "^1.0.0",
     "make-iterator": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This bump was just cutting the 0.1.5 version as 1.0.0 so this should be fine as a patch bump